### PR TITLE
allow insecure HTTP by default when using a customized OAuthWithJwtTo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There are multiple overloads of the `UseOauthWithJwtTokens` extensions method:
         
 	        public virtual AllowedOrigins AllowedOrigins => AllowedOrigins.All;
 
-        	public virtual bool AllowInsecureHttp => false;
+        	public virtual bool AllowInsecureHttp => true;
 
 	        public virtual string TokenEndpointPath => "/oauth/token";
 			

--- a/source/froko.Owin.Security.Jwt/OAuthWithJwtTokens.cs
+++ b/source/froko.Owin.Security.Jwt/OAuthWithJwtTokens.cs
@@ -51,9 +51,9 @@ namespace froko.Owin.Security.Jwt
         public virtual AllowedOrigins AllowedOrigins => AllowedOrigins.All;
 
         /// <summary>
-        /// Gets the fact that insecure HTTP is allowed (Default: false / not allowed)
+        /// Gets the fact that insecure HTTP is allowed (Default: true / allowed)
         /// </summary>
-        public virtual bool AllowInsecureHttp => false;
+        public virtual bool AllowInsecureHttp => true;
 
         /// <summary>
         /// Gets the token endpoint path


### PR DESCRIPTION
…ken class in order to be compliant with the behavior of other variants